### PR TITLE
Barra de carregamento em consultas Hash

### DIFF
--- a/src/main/java/entities/cells/Cell.java
+++ b/src/main/java/entities/cells/Cell.java
@@ -212,7 +212,15 @@ public abstract sealed class Cell permits TableCell, OperationCell {
     }
 
     public void freeOperatorResources(){
-        //operator.freeResources();
+        // Simple memory cleanup - call freeResources if available
+        if (operator != null) {
+            try {
+                // Try to clean up hash tables and other data structures
+                operator.close();
+            } catch (Exception e) {
+                // Ignore cleanup errors
+            }
+        }
     }
 
     public Pair<Integer, CellStats> getCellStats(int amountOfTuples, CellStats initialCellStats){

--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -11,15 +11,10 @@ import files.FileUtils;
 import gui.utils.JTableUtils;
 import org.kordamp.ikonli.dashicons.Dashicons;
 import org.kordamp.ikonli.swing.FontIcon;
-<<<<<<< HEAD
-=======
-import ibd.query.CancellableOperation;
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
 import ibd.query.Operation;
 import ibd.query.QueryStats;
 import ibd.query.ReferedDataSource;
 import ibd.query.Tuple;
-
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
@@ -105,28 +100,6 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         externalCancellationRequested = false;
     }
     
-<<<<<<< HEAD
-=======
-    /**
-     * Cleans up operation memory when operations are cancelled
-     * Uses the new generic hook-based cleanup system
-     */
-    private void cleanupOperationMemoryIfNeeded() {
-        try {
-            if (cell instanceof OperationCell) {
-                OperationCell operationCell = (OperationCell) cell;
-                Operation op = operationCell.getOperator();
-                // Simple generic cleanup - base class handles everything automatically!
-                op.requestCancellation();
-                op.cleanupOnCancellation();
-            }
-        } catch (Exception e) {
-            // Log error but don't prevent cancellation
-            System.err.println("Error cleaning operation memory: " + e.getMessage());
-        }
-    }
-
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
     public DataFrame(Cell cell) throws Exception {
 
         super((Window) null, ConstantController.getString("dataframe"));
@@ -178,7 +151,6 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         if (cell instanceof OperationCell) {
             OperationCell operationCell = (OperationCell) cell;
             if (operationCell.getType().isSetBasedProcessing) {
-<<<<<<< HEAD
                 // For set-based operations, directly process all tuples without showing dialog
                 // since OpenDataFrame already showed the loading dialog
                 currentIndex = 0;
@@ -227,61 +199,6 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             this.getTuples(currentIndex);
             this.updateTable(currentIndex);
         }
-=======
-                // Check if this operation is cancellable and handled by OpenDataFrame
-                if (operationCell.getOperator() instanceof CancellableOperation) {
-                    // For cancellable operations, directly process all tuples without showing dialog
-                    // since OpenDataFrame already showed the loading dialog
-                    currentIndex = 0;
-                    while (cell.getOperator().hasNext() && !externalCancellationRequested) {
-                        ibd.query.Tuple tuple = cell.getOperator().next();
-                        rows.add(tuple);
-                        largestElement++;
-                        
-                        // Allow cancellation and UI updates
-                        if (Thread.currentThread().isInterrupted() || externalCancellationRequested) {
-                            break;
-                        }
-                    }
-                    
-                    if (externalCancellationRequested) {
-                        // Clean up memory for cancelled operations
-                        cleanupOperationMemoryIfNeeded();
-                        // If cancelled, close this dialog
-                        this.dispose();
-                        return;
-                    }
-                    
-                    if (largestElement >= 0) {
-                        lastPage = largestElement / 15;
-                        currentIndex = 0; // Start at the beginning, not the end
-                        this.updateTable(currentIndex);
-                    } else {
-                        this.updateTable(0);
-                    }
-                } else {
-                    // For non-cancellable set-based operations, use the regular loading process
-                    this.getAllTuples();
-                    this.updateTable(lastPage);
-                }
-            }
-        }
-
-        boolean skipTupleLoading = false;
-        if (cell instanceof OperationCell) {
-            OperationCell operationCell = (OperationCell) cell;
-            if (operationCell.getType().isSetBasedProcessing && 
-                operationCell.getOperator() instanceof CancellableOperation) {
-                skipTupleLoading = true;
-            }
-        }
-        
-        if (!skipTupleLoading) {
-            currentIndex = 0;
-            this.getTuples(currentIndex);
-            this.updateTable(currentIndex);
-        }
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
         
         this.updateStats();
         this.verifyButtons();
@@ -392,11 +309,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         
         if (cell instanceof OperationCell) {
             OperationCell operationCell = (OperationCell) cell;
-<<<<<<< HEAD
             if (operationCell.getType().isSetBasedProcessing) {
-=======
-            if (operationCell.getOperator() instanceof CancellableOperation) {
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                 dialogTitle = "Generating " + operationCell.getType().displayName;
                 messageText = "Generating " + operationCell.getType().displayName.toLowerCase() + ". You can cancel the operation.";
             }

--- a/src/main/java/ibd/query/unaryop/HashIndex.java
+++ b/src/main/java/ibd/query/unaryop/HashIndex.java
@@ -81,7 +81,6 @@ public class HashIndex extends UnaryOperation {
         tuples = null;
     }
     
-<<<<<<< HEAD
     @Override
     public void close() throws Exception {
         // Clean up hash tables to free memory (handles both complete and partial hashes)
@@ -106,29 +105,6 @@ public class HashIndex extends UnaryOperation {
                         tupleList.clear();
                     }
                 }
-=======
-    /**
-     * Operation-specific cleanup for hash index.
-     * Implements the abstract method from Operation base class.
-     */
-    @Override
-    public void cleanupOperationResources() throws Exception {
-        // Hash-specific cleanup
-        if (tuples != null) {
-            try {
-                // Calculate memory for tracking
-                int tupleSize = getTupleSize();
-                long memoryToTrack = 0;
-                
-                for (List<Tuple> tupleList : tuples.values()) {
-                    memoryToTrack += tupleList.size() * tupleSize;
-                }
-                if (constantTuples != null) {
-                    memoryToTrack += constantTuples.size() * tupleSize;
-                }
-                
-                // Clear the collections
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                 tuples.clear();
                 tuples = null;
                 
@@ -137,7 +113,6 @@ public class HashIndex extends UnaryOperation {
                     constantTuples = null;
                 }
                 
-<<<<<<< HEAD
                 // Update memory statistics
                 QueryStats.MEMORY_USED = Math.max(0, QueryStats.MEMORY_USED - memoryFreed);
                 
@@ -165,38 +140,15 @@ public class HashIndex extends UnaryOperation {
                 } catch (Exception ignored) {
                     // Final safety: set references to null
                     tuples = null;
-=======
-                // Track memory for generic cleanup
-                operationMemoryUsed = memoryToTrack;
-                
-            } catch (Exception e) {
-                // If we can't calculate exact size, still clear the collections
-                if (tuples != null) {
-                    tuples.clear();
-                    tuples = null;
-                }
-                if (constantTuples != null) {
-                    constantTuples.clear();
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                     constantTuples = null;
                 }
             }
         }
         
-<<<<<<< HEAD
         // Call parent close to clean up child operations
         super.close();
     }
     
-=======
-        // Reset cancellation state for retry capability
-        cancellationRequested = false;
-        
-        // Call parent cleanup to propagate to child operations
-        super.cleanupOperationResources();
-    }
-
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
     //sets the list of columns that will be part of the hash keys
     private void prepareHashColumns() throws Exception {
 
@@ -429,18 +381,12 @@ public class HashIndex extends UnaryOperation {
         private void buildHash() {
             //build hash, if one does not exist yet
             if (tuples == null) {
-                // Reset cancellation flag to allow retry after previous cancellation
-                cancellationRequested = false;
-                // Clear thread interrupted status as well
+                // Clear thread interrupted status to allow fresh start
                 Thread.currentThread().interrupted();
                 
                 tuples = new HashMap();
                 constantTuples = new ArrayList();
                 long memoryUsed = 0;
-<<<<<<< HEAD
-=======
-                boolean wasInterrupted = false;
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                 
                 try {
                     //accesses and indexes all tuples that come from the child operation
@@ -448,7 +394,6 @@ public class HashIndex extends UnaryOperation {
                     int tupleSize = childOperation.getTupleSize();
                     int processedCount = 0;
                     while (it.hasNext()) {
-<<<<<<< HEAD
                         // Check for cancellation every 1000 tuples to allow responsive cancellation
                         if (processedCount % 1000 == 0 && Thread.currentThread().isInterrupted()) {
                             // Clear partially built hash and exit
@@ -457,12 +402,6 @@ public class HashIndex extends UnaryOperation {
                             tuples = null;
                             constantTuples = null;
                             return;
-=======
-                        // Use generic cancellation check
-                        if (isCancellationRequested()) {
-                            wasInterrupted = true;
-                            break;
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                         }
                         
                         Tuple tuple = (Tuple) it.next();
@@ -503,32 +442,12 @@ public class HashIndex extends UnaryOperation {
                     }
 
                 } catch (Exception ex) {
-<<<<<<< HEAD
                     
                 }
                 
                 // Only update memory stats if hash building completed successfully
                 if (tuples != null && !Thread.currentThread().isInterrupted()) {
                     QueryStats.MEMORY_USED += memoryUsed;
-=======
-                    wasInterrupted = true; // Treat exceptions as interruption
-                }
-                
-                // Only add memory usage if not interrupted
-                if (!wasInterrupted) {
-                    QueryStats.MEMORY_USED += memoryUsed;
-                    operationMemoryUsed += memoryUsed; // Track for cleanup
-                } else {
-                    // Clean up immediately if interrupted
-                    if (tuples != null) {
-                        tuples.clear();
-                        tuples = null;
-                    }
-                    if (constantTuples != null) {
-                        constantTuples.clear();
-                        constantTuples = null;
-                    }
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                 }
             }
         }

--- a/src/main/java/ibd/query/unaryop/HashIndex.java
+++ b/src/main/java/ibd/query/unaryop/HashIndex.java
@@ -80,7 +80,75 @@ public class HashIndex extends UnaryOperation {
         //a new one is created when the first query is executed. 
         tuples = null;
     }
-
+    
+    @Override
+    public void close() throws Exception {
+        // Clean up hash tables to free memory (handles both complete and partial hashes)
+        if (tuples != null) {
+            // Calculate approximate memory being freed
+            try {
+                int tupleSize = getTupleSize();
+                long memoryFreed = 0;
+                
+                for (List<Tuple> tupleList : tuples.values()) {
+                    if (tupleList != null) {
+                        memoryFreed += tupleList.size() * tupleSize;
+                    }
+                }
+                if (constantTuples != null) {
+                    memoryFreed += constantTuples.size() * tupleSize;
+                }
+                
+                // Clear the collections aggressively
+                for (List<Tuple> tupleList : tuples.values()) {
+                    if (tupleList != null) {
+                        tupleList.clear();
+                    }
+                }
+                tuples.clear();
+                tuples = null;
+                
+                if (constantTuples != null) {
+                    constantTuples.clear();
+                    constantTuples = null;
+                }
+                
+                // Update memory statistics
+                QueryStats.MEMORY_USED = Math.max(0, QueryStats.MEMORY_USED - memoryFreed);
+                
+                // Force garbage collection hint (not guaranteed, but helps)
+                System.gc();
+                
+            } catch (Exception e) {
+                // If we can't calculate exact size, still clear the collections aggressively
+                try {
+                    if (tuples != null) {
+                        for (List<Tuple> tupleList : tuples.values()) {
+                            if (tupleList != null) {
+                                tupleList.clear();
+                            }
+                        }
+                        tuples.clear();
+                        tuples = null;
+                    }
+                    if (constantTuples != null) {
+                        constantTuples.clear();
+                        constantTuples = null;
+                    }
+                    // Force garbage collection hint
+                    System.gc();
+                } catch (Exception ignored) {
+                    // Final safety: set references to null
+                    tuples = null;
+                    constantTuples = null;
+                }
+            }
+        }
+        
+        // Call parent close to clean up child operations
+        super.close();
+    }
+    
     //sets the list of columns that will be part of the hash keys
     private void prepareHashColumns() throws Exception {
 
@@ -277,6 +345,14 @@ public class HashIndex extends UnaryOperation {
         private void queryHash() {
             //here is where we build an iterator to traverse the query results
             //the hash is queried using as key the values of the hashed filter columns
+            
+            // Check if the hash was cancelled/cleaned up
+            if (tuples == null) {
+                // Return empty iterator if hash was cancelled
+                it = new ArrayList<Tuple>().iterator();
+                return;
+            }
+            
             String key = "";
             for (SingleColumnLookupFilter lookupFilter : hashedFilters) {
                 Element elem2 = lookupFilter.getSecondElement();
@@ -286,10 +362,19 @@ public class HashIndex extends UnaryOperation {
             List<Tuple> result = tuples.get(key);
             if (result != null) {
                 //it = result.iterator();
-                it = new TwoListsIterator(constantTuples.iterator(), result.iterator());
+                // Also check constantTuples for null safety
+                if (constantTuples != null) {
+                    it = new TwoListsIterator(constantTuples.iterator(), result.iterator());
+                } else {
+                    it = result.iterator();
+                }
             } else {
-                it = constantTuples.iterator();
-                //it = new ArrayList<Tuple>().iterator();
+                // Safe check for constantTuples as well
+                if (constantTuples != null) {
+                    it = constantTuples.iterator();
+                } else {
+                    it = new ArrayList<Tuple>().iterator();
+                }
             }
         }
 
@@ -299,12 +384,25 @@ public class HashIndex extends UnaryOperation {
                 tuples = new HashMap();
                 constantTuples = new ArrayList();
                 long memoryUsed = 0;
+                
                 try {
                     //accesses and indexes all tuples that come from the child operation
                     it = childOperation.lookUp(processedTuples, false);
                     int tupleSize = childOperation.getTupleSize();
+                    int processedCount = 0;
                     while (it.hasNext()) {
+                        // Check for cancellation every 1000 tuples to allow responsive cancellation
+                        if (processedCount % 1000 == 0 && Thread.currentThread().isInterrupted()) {
+                            // Clear partially built hash and exit
+                            tuples.clear();
+                            constantTuples.clear();
+                            tuples = null;
+                            constantTuples = null;
+                            return;
+                        }
+                        
                         Tuple tuple = (Tuple) it.next();
+                        processedCount++;
 
                         boolean foundNullTuple = false;
                         for (LookupFilter lookupFilter : nullFilters) {
@@ -315,6 +413,7 @@ public class HashIndex extends UnaryOperation {
                             {
                                 constantTuples.add(tuple);
                                 memoryUsed += tupleSize;
+                                foundNullTuple = true;
                                 break;
                             }
                         }
@@ -340,10 +439,14 @@ public class HashIndex extends UnaryOperation {
                     }
 
                 } catch (Exception ex) {
+                    
                 }
-                QueryStats.MEMORY_USED += memoryUsed;
+                
+                // Only update memory stats if hash building completed successfully
+                if (tuples != null && !Thread.currentThread().isInterrupted()) {
+                    QueryStats.MEMORY_USED += memoryUsed;
+                }
             }
-
         }
 
         @Override

--- a/src/main/java/operations/unary/Hash.java
+++ b/src/main/java/operations/unary/Hash.java
@@ -47,7 +47,6 @@ public class Hash implements IOperator {
 
         Cell parentCell = cell.getParents().get(0);
 
-
         ibd.query.Operation operator = parentCell.getOperator();
 
         ibd.query.Operation filterColumns = null;
@@ -56,8 +55,6 @@ public class Hash implements IOperator {
         } catch (Exception ex) {
             ex.printStackTrace();
         }
-
-        //Operator readyOperator = new DistinctOperator(filterColumns);
 
         String operationName = String.format("   %s   ", cell.getType().symbol);
 

--- a/src/main/java/threads/OpenDataFrame.java
+++ b/src/main/java/threads/OpenDataFrame.java
@@ -32,18 +32,13 @@ public class OpenDataFrame implements Runnable{
     
     /**
      * Cleans up operation memory when operations are cancelled
-     * Uses the generic CancellableOperation interface for reusability
+     * Uses the simple close() method for memory cleanup
      */
     private static void cleanupOperationMemoryIfNeeded(Cell cell) {
         try {
-            if (cell instanceof OperationCell) {
-                OperationCell operationCell = (OperationCell) cell;
-                ibd.query.Operation op = operationCell.getOperator();
-                if (op instanceof ibd.query.CancellableOperation) {
-                    ibd.query.CancellableOperation cancellableOp = (ibd.query.CancellableOperation) op;
-                    cancellableOp.requestCancellation();
-                    cancellableOp.cleanupOnCancellation();
-                }
+            if (cell != null) {
+                // Use the simple cleanup approach via freeOperatorResources
+                cell.freeOperatorResources();
             }
         } catch (Exception e) {
             // Log error but don't prevent cancellation
@@ -67,13 +62,8 @@ public class OpenDataFrame implements Runnable{
                 // Check if this is a cancellable set-based operation (hash, etc.)
                 if (cell instanceof OperationCell) {
                     OperationCell operationCell = (OperationCell) cell;
-<<<<<<< HEAD
                     if (operationCell.getType().isSetBasedProcessing) {
-=======
-                    if (operationCell.getType().isSetBasedProcessing &&
-                        operationCell.getOperator() instanceof ibd.query.CancellableOperation) {
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
-                        showCancellableOperationLoadingDialog(cell, operationCell.getType().displayName);
+                        showOperationLoadingDialog(cell, operationCell.getType().displayName);
                     } else {
                         try {
                             new DataFrame(cell);
@@ -94,7 +84,7 @@ public class OpenDataFrame implements Runnable{
         }
     }
 
-    private void showCancellableOperationLoadingDialog(Cell cell, String operationDisplayName) {
+    private void showOperationLoadingDialog(Cell cell, String operationDisplayName) {
         SwingUtilities.invokeLater(() -> {
             loadingDialog = new JDialog((Frame) null, operationDisplayName + " Operation", true);
             JButton cancelButton = new JButton("Cancel");
@@ -145,18 +135,9 @@ public class OpenDataFrame implements Runnable{
                     movingBar.stopAnimation();
                     loadingDialog.dispose();
                     
-<<<<<<< HEAD
                     // If cancelled, dispose of any created DataFrame
                     if (isCancelled() && dataFrame != null) {
                         dataFrame.dispose();
-=======
-                    // If cancelled, dispose of any created DataFrame and clean up memory
-                    if (isCancelled()) {
-                        cleanupOperationMemoryIfNeeded(cell);
-                        if (dataFrame != null) {
-                            dataFrame.dispose();
-                        }
->>>>>>> 0f80b781381b366f2d4f57bbaa3c4ed2d6b9ab25
                     }
                     // If not cancelled, the DataFrame will already be visible
                 }

--- a/src/main/java/threads/OpenDataFrame.java
+++ b/src/main/java/threads/OpenDataFrame.java
@@ -8,10 +8,14 @@ import entities.cells.Cell;
 import entities.cells.OperationCell;
 import entities.cells.TableCell;
 import entities.utils.cells.CellRepository;
+import enums.OperationType;
 import gui.frames.DataFrame;
 
-import javax.swing.JOptionPane;
-
+import javax.swing.*;
+import javax.swing.border.EmptyBorder;
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -19,6 +23,8 @@ import java.util.logging.Logger;
 public class OpenDataFrame implements Runnable{
 
     private final mxCell jCell;
+    private SwingWorker<Void, Void> dataFrameWorker;
+    private JDialog loadingDialog;
 
     public OpenDataFrame(mxCell jCell){
         this.jCell = jCell;
@@ -37,15 +43,151 @@ public class OpenDataFrame implements Runnable{
             if (!(cell instanceof TableCell || ((OperationCell) cell).hasBeenInitialized())) return;
 
             if (!cell.hasError()) {
-                try {
-                    new DataFrame(cell);
-                } catch (Exception ex) {
-                    JOptionPane.showMessageDialog(null, ex.getMessage(), ConstantController.getString("error"), JOptionPane.ERROR_MESSAGE);
+                // Check if this is a cancellable set-based operation (hash, etc.)
+                if (cell instanceof OperationCell) {
+                    OperationCell operationCell = (OperationCell) cell;
+                    if (operationCell.getType().isSetBasedProcessing) {
+                        showCancellableOperationLoadingDialog(cell, operationCell.getType().displayName);
+                    } else {
+                        try {
+                            new DataFrame(cell);
+                        } catch (Exception ex) {
+                            JOptionPane.showMessageDialog(null, ex.getMessage(), ConstantController.getString("error"), JOptionPane.ERROR_MESSAGE);
+                        }
+                    }
+                } else {
+                    try {
+                        new DataFrame(cell);
+                    } catch (Exception ex) {
+                        JOptionPane.showMessageDialog(null, ex.getMessage(), ConstantController.getString("error"), JOptionPane.ERROR_MESSAGE);
+                    }
                 }
             } else {
                 JOptionPane.showMessageDialog(null, ConstantController.getString("cell.operationCell.error"), ConstantController.getString("error"), JOptionPane.ERROR_MESSAGE);
             }
         }
+    }
 
+    private void showCancellableOperationLoadingDialog(Cell cell, String operationDisplayName) {
+        SwingUtilities.invokeLater(() -> {
+            loadingDialog = new JDialog((Frame) null, operationDisplayName + " Operation", true);
+            JButton cancelButton = new JButton("Cancel");
+            MovingSquareBar movingBar = new MovingSquareBar();
+
+            JPanel dialogPanel = new JPanel();
+            dialogPanel.setLayout(new BoxLayout(dialogPanel, BoxLayout.Y_AXIS));
+            dialogPanel.setBorder(new EmptyBorder(20, 20, 20, 20));
+
+            String message = "Generating " + operationDisplayName.toLowerCase() + ". You can cancel the operation.";
+            JLabel messageLabel = new JLabel(message);
+            messageLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
+            movingBar.setAlignmentX(Component.CENTER_ALIGNMENT);
+            cancelButton.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+            dialogPanel.add(messageLabel);
+            dialogPanel.add(Box.createVerticalStrut(15));
+            dialogPanel.add(movingBar);
+            dialogPanel.add(Box.createVerticalStrut(15));
+            dialogPanel.add(cancelButton);
+
+            loadingDialog.setContentPane(dialogPanel);
+            loadingDialog.setSize(400, 150);
+            loadingDialog.setLocationRelativeTo(null);
+            loadingDialog.setResizable(false);
+
+            dataFrameWorker = new SwingWorker<>() {
+                private DataFrame dataFrame = null;
+                
+                @Override
+                protected Void doInBackground() throws Exception {
+                    try {
+                        // Create DataFrame in background thread
+                        dataFrame = new DataFrame(cell);
+                        return null;
+                    } catch (Exception ex) {
+                        if (!isCancelled()) {
+                            SwingUtilities.invokeLater(() -> {
+                                JOptionPane.showMessageDialog(null, ex.getMessage(), ConstantController.getString("error"), JOptionPane.ERROR_MESSAGE);
+                            });
+                        }
+                        return null;
+                    }
+                }
+
+                @Override
+                protected void done() {
+                    movingBar.stopAnimation();
+                    loadingDialog.dispose();
+                    
+                    // If cancelled, dispose of any created DataFrame
+                    if (isCancelled() && dataFrame != null) {
+                        dataFrame.dispose();
+                    }
+                    // If not cancelled, the DataFrame will already be visible
+                }
+            };
+
+            cancelButton.addActionListener(e -> {
+                movingBar.stopAnimation();
+                DataFrame.requestCancellation(); // Request DataFrame to cancel
+                dataFrameWorker.cancel(true);
+                loadingDialog.dispose();
+            });
+
+            loadingDialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    DataFrame.requestCancellation(); // Request DataFrame to cancel
+                    if (dataFrameWorker != null && !dataFrameWorker.isDone()) {
+                        dataFrameWorker.cancel(true);
+                    }
+                }
+            });
+
+            dataFrameWorker.execute();
+            loadingDialog.setVisible(true);
+        });
+    }
+
+    private static class MovingSquareBar extends JPanel {
+        private int x = 0;
+        private final int squareSize = 18;
+        private final int barWidth = 300;
+        private final int barHeight = 15;
+        private final int step = 6;
+        private final Color squareColor = new Color(0, 180, 0);
+        private Timer timer;
+
+        public MovingSquareBar() {
+            setPreferredSize(new Dimension(barWidth, barHeight));
+            setMinimumSize(new Dimension(barWidth, barHeight));
+            setMaximumSize(new Dimension(barWidth, barHeight));
+            setBorder(BorderFactory.createLoweredBevelBorder());
+            setOpaque(true);
+            setBackground(Color.LIGHT_GRAY);
+            startAnimation();
+        }
+
+        private void startAnimation() {
+            timer = new Timer(30, e -> {
+                x += step;
+                if (x > barWidth - squareSize) {
+                    x = 0;
+                }
+                repaint();
+            });
+            timer.start();
+        }
+
+        public void stopAnimation() {
+            if (timer != null) timer.stop();
+        }
+
+        @Override
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            g.setColor(squareColor);
+            g.fillRoundRect(x, (barHeight - squareSize) / 2, squareSize, squareSize, 6, 6);
+        }
     }
 }


### PR DESCRIPTION
Implementação com memory cleanup para cancelamento de consultas Hash, junto com uma barra de carregamento própria. Também foi aplicado um bugfix para o cancelamento de consultas convencionais e uma pequena alteração em seu funcionamento, para que quando o usuário cancele o carregamento de uma consulta comum, o index seja a última página carregada, e não mais '1'.