### PR TITLE
Ajusta regras de criação de edges do operador de junção, adiciona atalho Ctrl+A e formata memória do comparador para KB

### DIFF
--- a/src/main/java/controllers/MainController.java
+++ b/src/main/java/controllers/MainController.java
@@ -1148,6 +1148,9 @@ public class MainController extends MainFrame {
             }
 
             System.out.print("\n\n");
+        } else if (keyCode == KeyEvent.VK_A && (event.getModifiersEx() &  KeyEvent.CTRL_DOWN_MASK) != 0) {
+            Object[] allCells = graph.getChildVertices(graph.getDefaultParent());
+            graph.setSelectionCells(allCells);
         } else if (keyCode == KeyEvent.VK_A) {
             if (this.jCell != null && CellUtils.getActiveCell(this.jCell).isPresent()) {
                 CellUtils.getActiveCell(this.jCell).get().getTree().getTreeLayer();

--- a/src/main/java/entities/cells/OperationCell.java
+++ b/src/main/java/entities/cells/OperationCell.java
@@ -160,6 +160,23 @@ public final class OperationCell extends Cell {
     }
 
     public void addParent(Cell cell) {
+        if (cell == null) {
+            return;
+        }
+
+        if (this.parents.size() == 1) {
+            Object[] incomingEdges = MainFrame.getGraph().getIncomingEdges(this.getJCell());
+
+            if (incomingEdges.length == 1 && incomingEdges[0] instanceof mxCell edgeCell) {
+                Object edgeValue = edgeCell.getValue();
+
+                if (ConstantController.getString("right").equals(edgeValue)) {
+                    this.parents.add(0, cell);
+                    return;
+                }
+            }
+        }
+
         this.parents.add(cell);
     }
 

--- a/src/main/java/entities/cells/OperationCell.java
+++ b/src/main/java/entities/cells/OperationCell.java
@@ -35,7 +35,9 @@ public final class OperationCell extends Cell {
 
     private final OperationType type;
 
-    private List<Cell> parents;
+    private Cell leftParent;
+
+    private Cell rightParent;
 
     private final OperationArity arity;
 
@@ -56,7 +58,8 @@ public final class OperationCell extends Cell {
                 type.getFormattedDisplayName(), jCell, ConstantController.OPERATION_CELL_HEIGHT
         );
 
-        this.parents = new ArrayList<>();
+        this.leftParent = null;
+        this.rightParent = null;
         this.arguments = new ArrayList<>();
         this.error = false;
         this.errorMessage = null;
@@ -73,20 +76,28 @@ public final class OperationCell extends Cell {
         this.arguments = arguments;
         this.alias = alias;
 
-        //if (parents != null && !parents.isEmpty()) 
-        
+        //if (parents != null && !parents.isEmpty())
+
         {
             this.hasBeenInitialized = true;
-            this.parents = parents;
 
-            parents.forEach(parent -> {
+            if (parents != null && !parents.isEmpty()) {
+                if (parents.size() >= 1) {
+                    this.leftParent = parents.get(0);
+                }
+                if (parents.size() >= 2) {
+                    this.rightParent = parents.get(1);
+                }
+            }
+
+            for (Cell parent : getParents()) {
                 parent.setChild(this);
                 if (this.canBeChild()) {
                     MainFrame.getGraph().insertEdge(parent.getJCell(), null, "", parent.getJCell(), jCell);
                 } else {
                     System.err.println("Warning: Attempted to create edge to cell that cannot be a child");
                 }
-            });
+            }
 
             this.updateOperation();
         }
@@ -156,7 +167,22 @@ public final class OperationCell extends Cell {
 
     @Override
     public List<Cell> getParents() {
-        return this.parents;
+        List<Cell> parents = new ArrayList<>(2);
+        if (this.leftParent != null) {
+            parents.add(this.leftParent);
+        }
+        if (this.rightParent != null) {
+            parents.add(this.rightParent);
+        }
+        return parents;
+    }
+
+    public Cell getLeftParent() {
+        return this.leftParent;
+    }
+
+    public Cell getRightParent() {
+        return this.rightParent;
     }
 
     public void addParent(Cell cell) {
@@ -164,24 +190,45 @@ public final class OperationCell extends Cell {
             return;
         }
 
-        if (this.parents.size() == 1) {
-            Object[] incomingEdges = MainFrame.getGraph().getIncomingEdges(this.getJCell());
-
-            if (incomingEdges.length == 1 && incomingEdges[0] instanceof mxCell edgeCell) {
-                Object edgeValue = edgeCell.getValue();
-
-                if (ConstantController.getString("right").equals(edgeValue)) {
-                    this.parents.add(0, cell);
-                    return;
-                }
-            }
+        if (cell.equals(this.leftParent) || cell.equals(this.rightParent)) {
+            return;
         }
 
-        this.parents.add(cell);
+        if (this.arity == OperationArity.UNARY) {
+            if (this.leftParent == null && this.rightParent == null) {
+                this.leftParent = cell;
+            }
+            return;
+        }
+
+        if (this.leftParent == null && this.rightParent == null) {
+            this.leftParent = cell;
+            return;
+        }
+
+        if (this.leftParent == null) {
+            this.leftParent = cell;
+            return;
+        }
+
+        if (this.rightParent == null) {
+            this.rightParent = cell;
+        }
     }
 
     public void removeParent(Cell cell) {
-        this.parents.remove(cell);
+        if (cell == null) {
+            return;
+        }
+
+        if (cell.equals(this.leftParent)) {
+            this.leftParent = null;
+            return;
+        }
+
+        if (cell.equals(this.rightParent)) {
+            this.rightParent = null;
+        }
     }
 
     public void removeParent(mxCell jCell) {
@@ -195,12 +242,13 @@ public final class OperationCell extends Cell {
     }
 
     public void removeParents() {
-        this.parents.clear();
+        this.leftParent = null;
+        this.rightParent = null;
     }
 
     @Override
     public boolean hasParents() {
-        return !this.parents.isEmpty();
+        return this.leftParent != null || this.rightParent != null;
     }
 
     public Boolean hasTree() {
@@ -272,8 +320,10 @@ public final class OperationCell extends Cell {
 
     public void reset() {
         this.name = this.type.getFormattedDisplayName();
-        this.parents.clear();
-        this.arguments.clear();        this.hasBeenInitialized = false;
+        this.leftParent = null;
+        this.rightParent = null;
+        this.arguments.clear();
+        this.hasBeenInitialized = false;
 
         this.removeError();
 
@@ -299,9 +349,9 @@ public final class OperationCell extends Cell {
         operationCell.arguments = new ArrayList<>(this.arguments);
         operationCell.hasBeenInitialized = this.hasBeenInitialized;
         operationCell.error = this.error;
-        operationCell.errorMessage = this.errorMessage;        // IMPORTANT: Don't copy parents list - the copied cell should be independent
-        // operationCell.parents remains empty (new ArrayList<>() from constructor)
-        // This ensures the copied cell has no parent relationships initially        // Don't copy the operator - it will be rebuilt by TreeUtils.recalculateContent()
+        operationCell.errorMessage = this.errorMessage;
+        // IMPORTANT: Don't copy parents - left/right stay null so the copy is independent.
+        // Don't copy the operator - it will be rebuilt by TreeUtils.recalculateContent()
         // This ensures no shared state between original and copied cells
         operationCell.setOperator(null);
           // Ensure columns are independent copies if they exist
@@ -319,7 +369,8 @@ public final class OperationCell extends Cell {
     public void updateFrom(OperationCell cell) {
         this.name = cell.name;
         this.alias = cell.alias;
-        this.parents = cell.parents;
+        this.leftParent = cell.leftParent;
+        this.rightParent = cell.rightParent;
         this.arguments = cell.arguments;
         this.hasBeenInitialized = cell.hasBeenInitialized;
         this.error = cell.error;
@@ -397,7 +448,7 @@ public final class OperationCell extends Cell {
             for (String columnName : contentInfo.getValue()) {
                 Column column = new Column(columnName, contentInfo.getKey(), ColumnDataType.NONE, false);
 
-                for (Cell parent : this.parents) {
+                for (Cell parent : getParents()) {
                     Column finalColumn = column;
                     column = parent.getColumns().stream().filter(c -> c.equals(finalColumn)).findAny().orElse(column);
                 }
@@ -413,7 +464,7 @@ public final class OperationCell extends Cell {
     public boolean hasParentErrors() {
         boolean error = false;
 
-        for (Cell cell : this.parents) {
+        for (Cell cell : getParents()) {
             if (cell.hasError()) {
                 error = true;
             }
@@ -462,18 +513,25 @@ public final class OperationCell extends Cell {
 
         columns = newColumns;
     }    public void setParents(List<Cell> newParents) {
-        for (Cell oldParent : this.parents) {
-            if (oldParent.getChild() == this) {
-                oldParent.removeChild();
-            }
+        if (this.leftParent != null && this.leftParent.getChild() == this) {
+            this.leftParent.removeChild();
+        }
+        if (this.rightParent != null && this.rightParent.getChild() == this) {
+            this.rightParent.removeChild();
         }
 
-        this.parents.clear();
+        this.leftParent = null;
+        this.rightParent = null;
 
-        if (newParents != null) {
-            this.parents.addAll(newParents);
+        if (newParents != null && !newParents.isEmpty()) {
+            if (newParents.size() >= 1) {
+                this.leftParent = newParents.get(0);
+            }
+            if (newParents.size() >= 2) {
+                this.rightParent = newParents.get(1);
+            }
 
-            for (Cell newParent : newParents) {
+            for (Cell newParent : getParents()) {
                 newParent.setChild(this);
             }
         }

--- a/src/main/java/gui/frames/ComparatorFrame.java
+++ b/src/main/java/gui/frames/ComparatorFrame.java
@@ -45,6 +45,7 @@ public class ComparatorFrame extends JFrame implements ActionListener {
     private int totalTuples = 0;    private SwingWorker<Void, Void> tupleLoaderWorker;
     private JDialog cancelDialog;
     private final DecimalFormat numberFormatter = new DecimalFormat("#,###");
+    private final DecimalFormat memoryFormatter = new DecimalFormat("#,###.##");
 
     public ComparatorFrame() {
 
@@ -205,7 +206,7 @@ public class ComparatorFrame extends JFrame implements ActionListener {
             Vector<String> row = new Vector<>();
             row.add(ConstantController.getString(parameterName));
             for (Long l : cellStats.get(parameterName)) {
-                row.add(String.valueOf(l));
+                row.add(formatStatValue(parameterName, l));
             }
             data.add(row);
         }
@@ -226,6 +227,15 @@ public class ComparatorFrame extends JFrame implements ActionListener {
 
         firstColumn.setPreferredWidth(maxWidth);
         jTable.revalidate();
+    }
+
+    private String formatStatValue(String parameterName, long value) {
+        if (parameterName.startsWith("MEMORY_")) {
+            double valueInKb = value / 1024.0;
+            return memoryFormatter.format(valueInKb) + " KB";
+        }
+
+        return String.valueOf(value);
     }
     
     @Override

--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -23,6 +23,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +86,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     private int currentLastPage = -1;
 
     private int largestElement = -1;
+
+    private final DecimalFormat memoryFormatter = new DecimalFormat("#,###.##");
 
     private SwingWorker<Void, Tuple> tupleLoaderWorker;
     private JDialog cancelDialog;
@@ -550,7 +553,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
                 .append("\n")
                 .append(ConstantController.getString("MEMORY_USED"))
                 .append(" = ")
-                .append(QueryStats.MEMORY_USED - this.INITIAL_MEMORY_USAGE)
+                .append(formatMemoryKb(QueryStats.MEMORY_USED - this.INITIAL_MEMORY_USAGE))
                 .append("\n\n")
                 .append(ConstantController.getString("dataframe.disk"))
                 .append(":")
@@ -592,6 +595,11 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
 
         this.revalidate();
         this.repaint();
+    }
+
+    private String formatMemoryKb(long value) {
+        double valueInKb = value / 1024.0;
+        return memoryFormatter.format(valueInKb) + " KB";
     }
     
     private void closeWindow() {

--- a/src/main/java/gui/frames/forms/operations/JoinForm.java
+++ b/src/main/java/gui/frames/forms/operations/JoinForm.java
@@ -71,8 +71,11 @@ public class JoinForm extends OperationForm implements ActionListener, IOperatio
 //		setColumns(comboBoxColumn2, comboBoxSource2, parent1);
         rightChild = null;
 
-        if (CellUtils.getActiveCell(jCell).get().getParents().size() == 2) {
-            this.rightChild = CellUtils.getActiveCell(jCell).get().getParents().get(1);
+        if (CellUtils.getActiveCell(jCell).get() instanceof entities.cells.OperationCell operationCell) {
+            this.rightChild = operationCell.getRightParent();
+        }
+
+        if (this.rightChild != null) {
 //			parent2.getColumns().stream()
 //					.map(column -> column.SOURCE).distinct()
 //					.forEach(comboBoxSource::addItem);
@@ -164,7 +167,7 @@ public class JoinForm extends OperationForm implements ActionListener, IOperatio
         checkBtnReady();
 
         if (e.getSource() == comboBoxSource) {
-            if (leftChild.getColumns().stream().anyMatch(column -> column.SOURCE.
+            if (leftChild != null && leftChild.getColumns().stream().anyMatch(column -> column.SOURCE.
                     equals(Objects.requireNonNull(comboBoxSource.getSelectedItem()).toString()))) {
 
                 setColumns(comboBoxColumn, comboBoxSource, leftChild.getColumns());
@@ -218,6 +221,10 @@ public class JoinForm extends OperationForm implements ActionListener, IOperatio
 
     private void autoJoin() {
         ArrayList<String> joins = new ArrayList<>();
+
+        if (leftChild == null || rightChild == null) {
+            return;
+        }
 
         leftChild.getColumns().forEach(leftColumn -> {
             rightChild.getColumns().forEach(rightColumn -> {

--- a/src/main/java/gui/frames/forms/operations/OperationForm.java
+++ b/src/main/java/gui/frames/forms/operations/OperationForm.java
@@ -52,11 +52,7 @@ public abstract class OperationForm extends FormBase {
         this.operator = cell.getType().operatorClass;
         this.jCell = jCell;
 
-        if (cell.getParents() != null && !cell.getParents().isEmpty()) {
-            this.leftChild = cell.getParents().get(0);
-        } else {
-            this.leftChild = null;
-        }
+        this.leftChild = cell.getLeftParent();
 
         if (!cell.getArguments().isEmpty()) {
             previousArguments.addAll(cell.getArguments());
@@ -118,16 +114,30 @@ public abstract class OperationForm extends FormBase {
     }
 
     protected void setLeftComboBoxData(Cell cell) {
-        Cell parentCell = cell.getParents().get(0);
+        if (!(cell instanceof OperationCell operationCell)) {
+            return;
+        }
+
+        Cell parentCell = operationCell.getLeftParent();
+        if (parentCell == null) {
+            return;
+        }
+
         setComboBoxData(parentCell.getColumns(), comboBoxSource, comboBoxColumn);
 
     }
 
     protected java.util.List<Column> setLeftComboBoxColumns(Cell cell) {
         //OperationCell cell = (OperationCell) CellUtils.getActiveCell(jCell).get();
-        if (cell.getParents().isEmpty())
+        if (!(cell instanceof OperationCell operationCell)) {
             return new ArrayList();
-        Cell parentCell = cell.getParents().get(0);
+        }
+
+        Cell parentCell = operationCell.getLeftParent();
+        if (parentCell == null) {
+            return new ArrayList();
+        }
+
         return new ArrayList(parentCell.getColumns());
 
     }

--- a/src/main/java/operations/binary/joins/JoinOperators.java
+++ b/src/main/java/operations/binary/joins/JoinOperators.java
@@ -75,8 +75,33 @@ public abstract class JoinOperators implements IOperator {
         }
         Object[] edges = MainController.getGraph().getIncomingEdges(jCell);
 
-        MainController.getGraph().getModel().setValue(edges[0], ConstantController.getString("left"));
-        MainController.getGraph().getModel().setValue(edges[1], ConstantController.getString("right"));
+        if (edges.length < 2) {
+            if (edges.length == 1) {
+                MainController.getGraph().getModel().setValue(edges[0], ConstantController.getString("left"));
+            }
+
+            return;
+        }
+
+        String leftLabel = ConstantController.getString("left");
+        String rightLabel = ConstantController.getString("right");
+        Object firstEdgeValue = MainController.getGraph().getModel().getValue(edges[0]);
+        Object secondEdgeValue = MainController.getGraph().getModel().getValue(edges[1]);
+
+        if (leftLabel.equals(firstEdgeValue) || rightLabel.equals(secondEdgeValue)) {
+            MainController.getGraph().getModel().setValue(edges[0], leftLabel);
+            MainController.getGraph().getModel().setValue(edges[1], rightLabel);
+            return;
+        }
+
+        if (rightLabel.equals(firstEdgeValue) || leftLabel.equals(secondEdgeValue)) {
+            MainController.getGraph().getModel().setValue(edges[0], rightLabel);
+            MainController.getGraph().getModel().setValue(edges[1], leftLabel);
+            return;
+        }
+
+        MainController.getGraph().getModel().setValue(edges[0], leftLabel);
+        MainController.getGraph().getModel().setValue(edges[1], rightLabel);
     }
     
     

--- a/src/main/java/operations/binary/joins/JoinOperators.java
+++ b/src/main/java/operations/binary/joins/JoinOperators.java
@@ -29,6 +29,9 @@ public abstract class JoinOperators implements IOperator {
         OperationCell cell = (OperationCell) optionalCell.get();
         OperationErrorType errorType = null;
 
+        Cell leftParent = null;
+        Cell rightParent = null;
+
         try {
             //errorType = OperationErrorType.NULL_ARGUMENT;
             //OperationErrorVerifier.noNullArgument(arguments);
@@ -45,8 +48,11 @@ public abstract class JoinOperators implements IOperator {
             errorType = OperationErrorType.PARENT_ERROR;
             OperationErrorVerifier.noParentError(cell);
 
+            leftParent = cell.getLeftParent();
+            rightParent = cell.getRightParent();
+
             errorType = OperationErrorType.SAME_SOURCE;
-            OperationErrorVerifier.haveDifferentSources(cell.getParents().get(0), cell.getParents().get(1));
+            OperationErrorVerifier.haveDifferentSources(leftParent, rightParent);
 
             errorType = null;
         } catch (TreeException exception) {
@@ -55,8 +61,8 @@ public abstract class JoinOperators implements IOperator {
 
         if (errorType != null) return;
 
-        Cell parentCell1 = cell.getParents().get(0);
-        Cell parentCell2 = cell.getParents().get(1);
+        Cell parentCell1 = leftParent;
+        Cell parentCell2 = rightParent;
 
         ibd.query.Operation operator1 = parentCell1.getOperator();
         ibd.query.Operation operator2 = parentCell2.getOperator();
@@ -73,35 +79,7 @@ public abstract class JoinOperators implements IOperator {
         } catch (Exception exception) {
             cell.setError(exception.getMessage());
         }
-        Object[] edges = MainController.getGraph().getIncomingEdges(jCell);
-
-        if (edges.length < 2) {
-            if (edges.length == 1) {
-                MainController.getGraph().getModel().setValue(edges[0], ConstantController.getString("left"));
-            }
-
-            return;
-        }
-
-        String leftLabel = ConstantController.getString("left");
-        String rightLabel = ConstantController.getString("right");
-        Object firstEdgeValue = MainController.getGraph().getModel().getValue(edges[0]);
-        Object secondEdgeValue = MainController.getGraph().getModel().getValue(edges[1]);
-
-        if (leftLabel.equals(firstEdgeValue) || rightLabel.equals(secondEdgeValue)) {
-            MainController.getGraph().getModel().setValue(edges[0], leftLabel);
-            MainController.getGraph().getModel().setValue(edges[1], rightLabel);
-            return;
-        }
-
-        if (rightLabel.equals(firstEdgeValue) || leftLabel.equals(secondEdgeValue)) {
-            MainController.getGraph().getModel().setValue(edges[0], rightLabel);
-            MainController.getGraph().getModel().setValue(edges[1], leftLabel);
-            return;
-        }
-
-        MainController.getGraph().getModel().setValue(edges[0], leftLabel);
-        MainController.getGraph().getModel().setValue(edges[1], rightLabel);
+        updateJoinEdgeLabels(jCell, leftParent, rightParent);
     }
     
     
@@ -112,6 +90,36 @@ public abstract class JoinOperators implements IOperator {
     }
     return String.join(" and ", arguments);
 }
+
+    private void updateJoinEdgeLabels(mxCell jCell, Cell leftParent, Cell rightParent) {
+        Object[] edges = MainController.getGraph().getIncomingEdges(jCell);
+        if (edges.length == 0) {
+            return;
+        }
+
+        String leftLabel = ConstantController.getString("left");
+        String rightLabel = ConstantController.getString("right");
+
+        for (Object edge : edges) {
+            if (!(edge instanceof mxCell edgeCell)) {
+                continue;
+            }
+
+            Object source = edgeCell.getSource();
+            if (!(source instanceof mxCell sourceCell)) {
+                continue;
+            }
+
+            if (leftParent != null && sourceCell == leftParent.getJCell()) {
+                MainController.getGraph().getModel().setValue(edgeCell, leftLabel);
+                continue;
+            }
+
+            if (rightParent != null && sourceCell == rightParent.getJCell()) {
+                MainController.getGraph().getModel().setValue(edgeCell, rightLabel);
+            }
+        }
+    }
 
     abstract ibd.query.Operation createJoinOperator(ibd.query.Operation operator1, ibd.query.Operation operator2, BooleanExpression booleanExpression);
     abstract ibd.query.Operation createJoinOperator(ibd.query.Operation operator1, ibd.query.Operation operator2, JoinPredicate joinPredicate);


### PR DESCRIPTION
1. Operador de junção (edges): O problema atual era que quando o edge da esquerda era removido, ao recriá-lo ele se tornava direito. Isso ocorria pois o armazenamento era feito em ArrayList (índice 0 = esquerda). Removendo o índice 0, o direito passava a ocupar essa posição. A solução adotada foi substituir esse ArrayList por variáveis separadas (leftParent / rightParent). Em que na nova regra: sem nenhum edge → cria esquerda, com edge de um lado → cria o oposto.

2. Atalho Ctrl+A: Adicionado suporte a Ctrl+A para selecionar todos os componentes.

3. Memória do comparador: Antes exibida em bytes (valores grandes). Agora formatada para KB, inclusive quando executado diretamente pela célula.

