### PR TITLE
DEVS:

### DIFF
--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -37,6 +37,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
 
     private final JLabel lblTuplesLoaded = new JLabel();
 
+    private final JLabel lblExecutionTime = new JLabel();
+
     private final JTable table = new JTable();
 
     private final JButton btnLeft = new JButton();
@@ -305,6 +307,14 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         }
     }
 
+    private static String formatElapsed(long elapsedNanos) {
+        long totalMs = elapsedNanos / 1_000_000L;
+        long minutes = totalMs / 60_000;
+        long seconds = (totalMs / 1_000) % 60;
+        long centis = (totalMs / 10) % 100;
+        return String.format("%02d:%02d.%02d", minutes, seconds, centis);
+    }
+
     private void getAllTuples() throws Exception {
         // Determine dialog title and message based on operation type
         String dialogTitle = "Loading All Tuples";
@@ -331,16 +341,27 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         movingBar.setAlignmentX(Component.CENTER_ALIGNMENT);
         cancelButton.setAlignmentX(Component.CENTER_ALIGNMENT);
 
+        JLabel lblElapsed = new JLabel(formatElapsed(0));
+        lblElapsed.setAlignmentX(Component.CENTER_ALIGNMENT);
+
         dialogPanel.add(messageLabel);
         dialogPanel.add(Box.createVerticalStrut(15));
         dialogPanel.add(movingBar);
+        dialogPanel.add(Box.createVerticalStrut(10));
+        dialogPanel.add(lblElapsed);
         dialogPanel.add(Box.createVerticalStrut(15));
         dialogPanel.add(cancelButton);
 
         cancelDialog.setContentPane(dialogPanel);
-        cancelDialog.setSize(400, 150);
+        cancelDialog.setSize(400, 180);
         cancelDialog.setLocationRelativeTo(this);
         cancelDialog.setResizable(false);
+
+        final long startNanos = System.nanoTime();
+        final Timer elapsedTimer = new Timer(100, e ->
+            lblElapsed.setText(formatElapsed(System.nanoTime() - startNanos))
+        );
+
         tupleLoaderWorker = new SwingWorker<>() {
             @Override
             protected Void doInBackground() throws Exception {
@@ -355,6 +376,10 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             @Override
             protected void done() {
                 movingBar.stopAnimation();
+                elapsedTimer.stop();
+                lblExecutionTime.setText(
+                    ConstantController.getString("dataframe.executionTime")
+                        + ": " + formatElapsed(System.nanoTime() - startNanos));
                 cancelDialog.dispose();
                 
                 if (isCancelled()) {
@@ -414,6 +439,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             }
         });
 
+        elapsedTimer.start();
         tupleLoaderWorker.execute();
         cancelDialog.setVisible(true);
     }
@@ -435,6 +461,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         northPane.add(this.lblText);
         northPane.add(this.lblPages);
         northPane.add(this.lblTuplesLoaded);
+        northPane.add(this.lblExecutionTime);
         northPane.add(this.btnStats);
 
         this.tablePanel.add(this.table.getTableHeader(), BorderLayout.NORTH);

--- a/src/main/java/gui/frames/forms/operations/unary/AsOperatorForm.java
+++ b/src/main/java/gui/frames/forms/operations/unary/AsOperatorForm.java
@@ -4,6 +4,8 @@ import controllers.ConstantController;
 import gui.frames.forms.FormBase;
 import gui.frames.forms.IFormCondition;
 
+import javax.swing.JButton;
+import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.UIManager;
 import javax.swing.event.DocumentEvent;
@@ -11,6 +13,7 @@ import javax.swing.event.DocumentListener;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
@@ -20,6 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class AsOperatorForm extends FormBase implements ActionListener, IFormCondition {
 
     private final JTextField textField = new JTextField();
+
+    private final JButton btnErase = new JButton(ConstantController.getString("operationForm.clear"));
 
     private final AtomicReference<Boolean> cancelService;
 
@@ -40,7 +45,8 @@ public class AsOperatorForm extends FormBase implements ActionListener, IFormCon
 
         btnCancel.addActionListener(this);
         btnReady.addActionListener(this);
-        
+        btnErase.addActionListener(this);
+
         textField.setText(text);
 
         textField.getDocument().addDocumentListener(new DocumentListener() {
@@ -61,6 +67,11 @@ public class AsOperatorForm extends FormBase implements ActionListener, IFormCon
         });
 
         contentPanel.add(textField, BorderLayout.CENTER);
+
+        Component south = ((BorderLayout) contentPanel.getLayout()).getLayoutComponent(BorderLayout.SOUTH);
+        if (south instanceof JPanel) {
+            ((JPanel) south).add(btnErase, 0);
+        }
 
         checkBtnReady();
 
@@ -83,6 +94,11 @@ public class AsOperatorForm extends FormBase implements ActionListener, IFormCon
         }
 
         if(e.getSource() == this.btnReady){
+            dispose();
+        }
+
+        if(e.getSource() == this.btnErase){
+            textField.setText("");
             dispose();
         }
 

--- a/src/main/java/operations/Operation.java
+++ b/src/main/java/operations/Operation.java
@@ -44,6 +44,10 @@ public class Operation {
         String a = "";
         //if (operator instanceof SingleSource ssOp) 
         {
+            String preservedAlias = cell.getAlias();
+            if (preservedAlias != null && !preservedAlias.isEmpty()) {
+                operator.setDataSourceAlias(preservedAlias);
+            }
             cell.setAlias(operator.getDataSourceAlias());
             a = operator.getDataSourceAlias();
             if (!a.isBlank()) {

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -324,6 +324,7 @@ left=LEFT
 tableName=Table name
 asOperatorForm.toolTipText.blank=You must choose a name
 dataframe.tuplesLoaded=Tuples loaded
+dataframe.executionTime=Execution time
 # Enhanced Create Table Interface
 createTable.enhanced.title=Create Table - Enhanced Interface
 createTable.enhanced.columns.tab=Columns

--- a/src/main/resources/messages_pt_BR.properties
+++ b/src/main/resources/messages_pt_BR.properties
@@ -323,6 +323,7 @@ left=ESQUERDA
 tableName=Nome da tabela
 asOperatorForm.toolTipText.blank=Voc\u00ea deve escolher um nome
 dataframe.tuplesLoaded=Tuplas carregadas
+dataframe.executionTime=Tempo de execu\u00e7\u00e3o
 
 jdbc.connections.title=Conex\u00f5es
 jdbc.connections.new=Adicionar Conex\u00e3o


### PR DESCRIPTION
Adicionando tracking de tempo de execução, arquivos:
- DataFrame.java;
- messages_en_US.properties
- messages_pt_BR.properties

Permitindo erasing de nome após rename, arquivos:
- AsOperatorForm.java

Preservando nome de operador após alteração da árvore, arquivos: Operation.java
=============================
O fluxo do bug era:
TreeUtils.java (método recalculateContent()) ->
chamava OperationCell.java (método currentCell.updateOperation()) -> chamava IOperator.java (método executeOperation()) -> chamava implementação qualquer ->
chamava Operation.java (método operationSetter())
alias nao era preservado, nome padrão (nenhum) era usado