### PR TITLE
feature: query results table interactions

### DIFF
--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -18,6 +18,7 @@ import ibd.query.Tuple;
 import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
+import javax.swing.table.TableColumn;
 import java.awt.*;
 import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
@@ -28,6 +29,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,6 +108,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     private int selectedTableColumn = -1;
 
     private final Set<Integer> selectedLoadedColumns = new TreeSet<>();
+
+    private final Map<String, Integer> columnWidths = new HashMap<>();
 
     private final DecimalFormat memoryFormatter = new DecimalFormat("#,###.##");
 
@@ -261,6 +265,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         int firstElement = page * 15;
         int lastElement = page * 15 + 14;
 
+        this.saveColumnWidths();
+
         DefaultTableModel model = new ReadOnlyTableModel();
 
         model.addColumn("");
@@ -306,6 +312,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         }
 
         this.table.getColumnModel().getColumn(0).setResizable(false);
+        this.restoreColumnWidths();
 
         JTableUtils.setColumnBold(this.table, 0);
         JTableUtils.setNullInRed(this.table);
@@ -314,6 +321,28 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.table.setFillsViewportHeight(true);
         this.clearTableSelection();
         this.table.repaint();
+    }
+
+    private void saveColumnWidths() {
+        for (int i = 1; i < this.table.getColumnCount(); i++) {
+            TableColumn column = this.table.getColumnModel().getColumn(i);
+            String columnName = String.valueOf(column.getHeaderValue());
+            this.columnWidths.put(columnName, column.getWidth());
+        }
+    }
+
+    private void restoreColumnWidths() {
+        for (int i = 1; i < this.table.getColumnCount(); i++) {
+            TableColumn column = this.table.getColumnModel().getColumn(i);
+            String columnName = String.valueOf(column.getHeaderValue());
+            Integer width = this.columnWidths.get(columnName);
+            if (width == null || width <= 0) {
+                continue;
+            }
+
+            column.setPreferredWidth(width);
+            column.setWidth(width);
+        }
     }
 
     private void getTuples(int page) throws Exception {

--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,6 +48,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     private final JPopupMenu tablePopupMenu = new JPopupMenu();
 
     private final JMenuItem copyMenuItem = new JMenuItem("Copy");
+
+    private final JButton btnSelectLoaded = new JButton("All");
 
     private final JButton btnLeft = new JButton();
 
@@ -101,6 +104,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     private int selectedTableRow = -1;
 
     private int selectedTableColumn = -1;
+
+    private final Set<Integer> selectedLoadedColumns = new TreeSet<>();
 
     private final DecimalFormat memoryFormatter = new DecimalFormat("#,###.##");
 
@@ -248,6 +253,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.iconStats = FontIcon.of(Dashicons.BOOK);
         this.iconStats.setIconSize(buttonsSize);
         this.btnStats.setIcon(this.iconStats);
+
+        this.btnSelectLoaded.setToolTipText("Select loaded tuples");
     }
 
     private void updateTable(int page) throws Exception {
@@ -474,6 +481,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.btnRight.addActionListener(this);
         this.btnAllRight.addActionListener(this);
         this.btnStats.addActionListener(this);
+        this.btnSelectLoaded.addActionListener(this);
         this.configureTableInteraction();
 
         JPanel northPane = new JPanel(new FlowLayout());
@@ -481,6 +489,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         northPane.add(this.lblPages);
         northPane.add(this.lblTuplesLoaded);
         northPane.add(this.lblExecutionTime);
+        northPane.add(this.btnSelectLoaded);
         northPane.add(this.btnStats);
 
         this.tablePanel.add(this.table.getTableHeader(), BorderLayout.NORTH);
@@ -590,8 +599,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             return;
         }
 
-        if ((this.tableSelectionType == TableSelectionType.ROW && this.selectedTableRow == row)
-            || (this.tableSelectionType == TableSelectionType.COLUMN && this.selectedTableColumn == column)) {
+        if (this.tableSelectionType == TableSelectionType.ROW && this.selectedTableRow == row) {
             SwingUtilities.invokeLater(this::clearTableSelection);
             return;
         }
@@ -630,18 +638,48 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             return;
         }
 
-        boolean selectedColumn = this.tableSelectionType == TableSelectionType.COLUMN
-            && this.selectedTableColumn == column;
+        if (this.selectedLoadedColumns.contains(column)) {
+            this.selectedLoadedColumns.remove(column);
+        } else {
+            this.selectedLoadedColumns.add(column);
+        }
 
-        if (selectedColumn) {
+        if (this.selectedLoadedColumns.isEmpty()) {
             this.clearTableSelection();
+            return;
+        }
+
+        this.applyLoadedColumnSelection();
+        this.markColumnSelection(column);
+    }
+
+    private void selectAllLoadedRows() {
+        if (this.tableSelectionType == TableSelectionType.ALL_LOADED) {
+            this.clearTableSelection();
+            return;
+        }
+
+        if (this.rows.isEmpty() || this.table.getRowCount() == 0 || this.table.getColumnCount() <= 1) {
             return;
         }
 
         this.table.requestFocusInWindow();
         this.table.setRowSelectionInterval(0, this.table.getRowCount() - 1);
-        this.table.setColumnSelectionInterval(column, column);
-        this.markColumnSelection(column);
+        this.table.setColumnSelectionInterval(1, this.table.getColumnCount() - 1);
+        this.markAllLoadedSelection();
+    }
+
+    private void applyLoadedColumnSelection() {
+        this.table.requestFocusInWindow();
+        this.table.clearSelection();
+        if (this.table.getRowCount() > 0) {
+            this.table.setRowSelectionInterval(0, this.table.getRowCount() - 1);
+        }
+        for (Integer selectedColumn : this.selectedLoadedColumns) {
+            if (selectedColumn >= 0 && selectedColumn < this.table.getColumnCount()) {
+                this.table.addColumnSelectionInterval(selectedColumn, selectedColumn);
+            }
+        }
     }
 
     private void clearTableSelection() {
@@ -649,15 +687,18 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.tableSelectionType = TableSelectionType.NONE;
         this.selectedTableRow = -1;
         this.selectedTableColumn = -1;
+        this.selectedLoadedColumns.clear();
     }
 
     private void markCellSelection(int row, int column) {
+        this.selectedLoadedColumns.clear();
         this.tableSelectionType = TableSelectionType.CELL;
         this.selectedTableRow = row;
         this.selectedTableColumn = column;
     }
 
     private void markRowSelection(int row) {
+        this.selectedLoadedColumns.clear();
         this.tableSelectionType = TableSelectionType.ROW;
         this.selectedTableRow = row;
         this.selectedTableColumn = -1;
@@ -667,6 +708,13 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.tableSelectionType = TableSelectionType.COLUMN;
         this.selectedTableRow = -1;
         this.selectedTableColumn = column;
+    }
+
+    private void markAllLoadedSelection() {
+        this.selectedLoadedColumns.clear();
+        this.tableSelectionType = TableSelectionType.ALL_LOADED;
+        this.selectedTableRow = -1;
+        this.selectedTableColumn = -1;
     }
 
     private void showTablePopup(MouseEvent event) {
@@ -679,8 +727,13 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     }
 
     private void copySelectionToClipboard() {
-        if (this.tableSelectionType == TableSelectionType.COLUMN && this.selectedTableColumn >= 0) {
-            this.copyLoadedColumnToClipboard(this.selectedTableColumn);
+        if (this.tableSelectionType == TableSelectionType.ALL_LOADED) {
+            this.copyLoadedColumnsToClipboard(this.getDataColumnIndexes());
+            return;
+        }
+
+        if (this.tableSelectionType == TableSelectionType.COLUMN && !this.selectedLoadedColumns.isEmpty()) {
+            this.copyLoadedColumnsToClipboard(new ArrayList<>(this.selectedLoadedColumns));
             return;
         }
 
@@ -708,28 +761,45 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         copyTextToClipboard(clipboardText.toString());
     }
 
-    private void copyLoadedColumnToClipboard(int column) {
-        if (column >= this.table.getColumnCount() || this.rows.isEmpty()) {
+    private void copyLoadedColumnsToClipboard(List<Integer> columns) {
+        if (columns.isEmpty() || this.rows.isEmpty()) {
             return;
         }
 
         StringBuilder clipboardText = new StringBuilder();
-        String columnName = this.table.getColumnName(column);
         for (int rowIndex = 0; rowIndex < this.rows.size(); rowIndex++) {
             if (rowIndex > 0) {
                 clipboardText.append(System.lineSeparator());
             }
 
-            if (column == 0) {
-                clipboardText.append(rowIndex + 1);
-                continue;
-            }
-
             Map<String, String> currentRow = TuplesExtractor.getRow_(this.rows.get(rowIndex), this.cell.getOperator(), true);
-            clipboardText.append(formatClipboardValue(currentRow.get(columnName)));
+            for (int columnIndex = 0; columnIndex < columns.size(); columnIndex++) {
+                if (columnIndex > 0) {
+                    clipboardText.append('\t');
+                }
+
+                int column = columns.get(columnIndex);
+                if (column == 0) {
+                    clipboardText.append(rowIndex + 1);
+                    continue;
+                }
+
+                if (column > 0 && column < this.table.getColumnCount()) {
+                    String columnName = this.table.getColumnName(column);
+                    clipboardText.append(formatClipboardValue(currentRow.get(columnName)));
+                }
+            }
         }
 
         copyTextToClipboard(clipboardText.toString());
+    }
+
+    private List<Integer> getDataColumnIndexes() {
+        List<Integer> columns = new ArrayList<>();
+        for (int column = 1; column < this.table.getColumnCount(); column++) {
+            columns.add(column);
+        }
+        return columns;
     }
 
     private void copyTextToClipboard(String text) {
@@ -796,6 +866,9 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             }
             else if (event.getSource() == this.btnStats) {
                 this.alternateScreen();
+            }
+            else if (event.getSource() == this.btnSelectLoaded) {
+                this.selectAllLoadedRows();
             }
 
             this.updateTuplesLoaded();
@@ -905,7 +978,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         NONE,
         CELL,
         ROW,
-        COLUMN
+        COLUMN,
+        ALL_LOADED
     }
 
     private static class MovingSquareBar extends JPanel {

--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -19,8 +19,11 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.DefaultTableModel;
 import java.awt.*;
+import java.awt.datatransfer.StringSelection;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.text.DecimalFormat;
@@ -40,6 +43,10 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     private final JLabel lblExecutionTime = new JLabel();
 
     private final JTable table = new JTable();
+
+    private final JPopupMenu tablePopupMenu = new JPopupMenu();
+
+    private final JMenuItem copyMenuItem = new JMenuItem("Copy");
 
     private final JButton btnLeft = new JButton();
 
@@ -93,6 +100,8 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
 
     private SwingWorker<Void, Tuple> tupleLoaderWorker;
     private JDialog cancelDialog;
+
+    private static final String COPY_SELECTION_ACTION = "copySelection";
     
     // Static flag to allow external cancellation (e.g., from OpenDataFrame)
     private static volatile boolean externalCancellationRequested = false;
@@ -237,7 +246,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         int firstElement = page * 15;
         int lastElement = page * 15 + 14;
 
-        DefaultTableModel model = new DefaultTableModel();
+        DefaultTableModel model = new ReadOnlyTableModel();
 
         model.addColumn("");
 
@@ -286,7 +295,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         JTableUtils.setColumnBold(this.table, 0);
         JTableUtils.setNullInRed(this.table);
 
-        this.table.setEnabled(false);
+        this.table.setEnabled(true);
         this.table.setFillsViewportHeight(true);
         this.table.repaint();
     }
@@ -456,6 +465,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.btnRight.addActionListener(this);
         this.btnAllRight.addActionListener(this);
         this.btnStats.addActionListener(this);
+        this.configureTableInteraction();
 
         JPanel northPane = new JPanel(new FlowLayout());
         northPane.add(this.lblText);
@@ -496,6 +506,126 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         if (!externalCancellationRequested) {
             this.setVisible(true);
         }
+    }
+
+    private void configureTableInteraction() {
+        this.table.setEnabled(true);
+        this.table.setFocusable(true);
+        this.table.setCellSelectionEnabled(true);
+        this.table.setRowSelectionAllowed(true);
+        this.table.setColumnSelectionAllowed(true);
+        this.table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
+
+        this.table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+            .put(KeyStroke.getKeyStroke("control C"), COPY_SELECTION_ACTION);
+        this.table.getActionMap().put(COPY_SELECTION_ACTION, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                copySelectionToClipboard();
+            }
+        });
+
+        this.copyMenuItem.addActionListener(event -> copySelectionToClipboard());
+        this.tablePopupMenu.add(this.copyMenuItem);
+
+        this.table.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent event) {
+                selectRowFromIndexColumn(event);
+                showTablePopup(event);
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent event) {
+                showTablePopup(event);
+            }
+        });
+
+        this.table.getTableHeader().addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent event) {
+                selectColumnFromHeader(event);
+            }
+        });
+    }
+
+    private void selectRowFromIndexColumn(MouseEvent event) {
+        if (!SwingUtilities.isLeftMouseButton(event)) {
+            return;
+        }
+
+        int row = this.table.rowAtPoint(event.getPoint());
+        int column = this.table.columnAtPoint(event.getPoint());
+        if (row < 0 || column != 0 || this.table.getColumnCount() <= 1) {
+            return;
+        }
+
+        SwingUtilities.invokeLater(() -> {
+            this.table.requestFocusInWindow();
+            this.table.setRowSelectionInterval(row, row);
+            this.table.setColumnSelectionInterval(1, this.table.getColumnCount() - 1);
+        });
+    }
+
+    private void selectColumnFromHeader(MouseEvent event) {
+        if (!SwingUtilities.isLeftMouseButton(event) || this.table.getRowCount() == 0) {
+            return;
+        }
+
+        int column = this.table.columnAtPoint(event.getPoint());
+        if (column < 0) {
+            return;
+        }
+
+        this.table.requestFocusInWindow();
+        this.table.setRowSelectionInterval(0, this.table.getRowCount() - 1);
+        this.table.setColumnSelectionInterval(column, column);
+    }
+
+    private void showTablePopup(MouseEvent event) {
+        if (!event.isPopupTrigger()) {
+            return;
+        }
+
+        this.copyMenuItem.setEnabled(this.table.getSelectedRowCount() > 0 && this.table.getSelectedColumnCount() > 0);
+        this.tablePopupMenu.show(event.getComponent(), event.getX(), event.getY());
+    }
+
+    private void copySelectionToClipboard() {
+        int[] selectedRows = this.table.getSelectedRows();
+        int[] selectedColumns = this.table.getSelectedColumns();
+        if (selectedRows.length == 0 || selectedColumns.length == 0) {
+            return;
+        }
+
+        StringBuilder clipboardText = new StringBuilder();
+        for (int rowIndex = 0; rowIndex < selectedRows.length; rowIndex++) {
+            if (rowIndex > 0) {
+                clipboardText.append(System.lineSeparator());
+            }
+
+            for (int columnIndex = 0; columnIndex < selectedColumns.length; columnIndex++) {
+                if (columnIndex > 0) {
+                    clipboardText.append('\t');
+                }
+                Object value = this.table.getValueAt(selectedRows[rowIndex], selectedColumns[columnIndex]);
+                clipboardText.append(formatClipboardValue(value));
+            }
+        }
+
+        StringSelection selection = new StringSelection(clipboardText.toString());
+        this.table.getToolkit().getSystemClipboard().setContents(selection, null);
+    }
+
+    private String formatClipboardValue(Object value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value.toString()
+            .replace('\t', ' ')
+            .replace('\n', ' ')
+            .replace('\r', ' ');
     }
 
     private void updateTuplesLoaded() {
@@ -642,6 +772,13 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.cell.closeOperator();
         this.cell.freeOperatorResources();
         this.dispose();
+    }
+
+    private static class ReadOnlyTableModel extends DefaultTableModel {
+        @Override
+        public boolean isCellEditable(int row, int column) {
+            return false;
+        }
     }
 
     private static class MovingSquareBar extends JPanel {

--- a/src/main/java/gui/frames/DataFrame.java
+++ b/src/main/java/gui/frames/DataFrame.java
@@ -96,12 +96,20 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
 
     private int largestElement = -1;
 
+    private TableSelectionType tableSelectionType = TableSelectionType.NONE;
+
+    private int selectedTableRow = -1;
+
+    private int selectedTableColumn = -1;
+
     private final DecimalFormat memoryFormatter = new DecimalFormat("#,###.##");
 
     private SwingWorker<Void, Tuple> tupleLoaderWorker;
     private JDialog cancelDialog;
 
     private static final String COPY_SELECTION_ACTION = "copySelection";
+
+    private static final String CLEAR_SELECTION_ACTION = "clearSelection";
     
     // Static flag to allow external cancellation (e.g., from OpenDataFrame)
     private static volatile boolean externalCancellationRequested = false;
@@ -297,6 +305,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
 
         this.table.setEnabled(true);
         this.table.setFillsViewportHeight(true);
+        this.clearTableSelection();
         this.table.repaint();
     }
 
@@ -524,6 +533,14 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
                 copySelectionToClipboard();
             }
         });
+        this.table.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
+            .put(KeyStroke.getKeyStroke("ESCAPE"), CLEAR_SELECTION_ACTION);
+        this.table.getActionMap().put(CLEAR_SELECTION_ACTION, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                clearTableSelection();
+            }
+        });
 
         this.copyMenuItem.addActionListener(event -> copySelectionToClipboard());
         this.tablePopupMenu.add(this.copyMenuItem);
@@ -531,7 +548,7 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         this.table.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent event) {
-                selectRowFromIndexColumn(event);
+                handleTableSelectionClick(event);
                 showTablePopup(event);
             }
 
@@ -549,21 +566,57 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         });
     }
 
-    private void selectRowFromIndexColumn(MouseEvent event) {
+    private void handleTableSelectionClick(MouseEvent event) {
         if (!SwingUtilities.isLeftMouseButton(event)) {
             return;
         }
 
         int row = this.table.rowAtPoint(event.getPoint());
         int column = this.table.columnAtPoint(event.getPoint());
-        if (row < 0 || column != 0 || this.table.getColumnCount() <= 1) {
+        if (row < 0 || column < 0) {
+            this.clearTableSelection();
             return;
         }
 
+        if (column == 0) {
+            selectRowFromIndexColumn(row);
+            return;
+        }
+
+        if (this.tableSelectionType == TableSelectionType.CELL
+            && this.selectedTableRow == row
+            && this.selectedTableColumn == column) {
+            SwingUtilities.invokeLater(this::clearTableSelection);
+            return;
+        }
+
+        if ((this.tableSelectionType == TableSelectionType.ROW && this.selectedTableRow == row)
+            || (this.tableSelectionType == TableSelectionType.COLUMN && this.selectedTableColumn == column)) {
+            SwingUtilities.invokeLater(this::clearTableSelection);
+            return;
+        }
+
+        SwingUtilities.invokeLater(() -> markCellSelection(row, column));
+    }
+
+    private void selectRowFromIndexColumn(int row) {
+        if (row < 0 || this.table.getColumnCount() <= 1) {
+            return;
+        }
+
+        boolean selectedRow = this.tableSelectionType == TableSelectionType.ROW
+            && this.selectedTableRow == row;
+
         SwingUtilities.invokeLater(() -> {
+            if (selectedRow) {
+                this.clearTableSelection();
+                return;
+            }
+
             this.table.requestFocusInWindow();
             this.table.setRowSelectionInterval(row, row);
             this.table.setColumnSelectionInterval(1, this.table.getColumnCount() - 1);
+            this.markRowSelection(row);
         });
     }
 
@@ -577,9 +630,43 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             return;
         }
 
+        boolean selectedColumn = this.tableSelectionType == TableSelectionType.COLUMN
+            && this.selectedTableColumn == column;
+
+        if (selectedColumn) {
+            this.clearTableSelection();
+            return;
+        }
+
         this.table.requestFocusInWindow();
         this.table.setRowSelectionInterval(0, this.table.getRowCount() - 1);
         this.table.setColumnSelectionInterval(column, column);
+        this.markColumnSelection(column);
+    }
+
+    private void clearTableSelection() {
+        this.table.clearSelection();
+        this.tableSelectionType = TableSelectionType.NONE;
+        this.selectedTableRow = -1;
+        this.selectedTableColumn = -1;
+    }
+
+    private void markCellSelection(int row, int column) {
+        this.tableSelectionType = TableSelectionType.CELL;
+        this.selectedTableRow = row;
+        this.selectedTableColumn = column;
+    }
+
+    private void markRowSelection(int row) {
+        this.tableSelectionType = TableSelectionType.ROW;
+        this.selectedTableRow = row;
+        this.selectedTableColumn = -1;
+    }
+
+    private void markColumnSelection(int column) {
+        this.tableSelectionType = TableSelectionType.COLUMN;
+        this.selectedTableRow = -1;
+        this.selectedTableColumn = column;
     }
 
     private void showTablePopup(MouseEvent event) {
@@ -592,6 +679,11 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
     }
 
     private void copySelectionToClipboard() {
+        if (this.tableSelectionType == TableSelectionType.COLUMN && this.selectedTableColumn >= 0) {
+            this.copyLoadedColumnToClipboard(this.selectedTableColumn);
+            return;
+        }
+
         int[] selectedRows = this.table.getSelectedRows();
         int[] selectedColumns = this.table.getSelectedColumns();
         if (selectedRows.length == 0 || selectedColumns.length == 0) {
@@ -613,7 +705,35 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
             }
         }
 
-        StringSelection selection = new StringSelection(clipboardText.toString());
+        copyTextToClipboard(clipboardText.toString());
+    }
+
+    private void copyLoadedColumnToClipboard(int column) {
+        if (column >= this.table.getColumnCount() || this.rows.isEmpty()) {
+            return;
+        }
+
+        StringBuilder clipboardText = new StringBuilder();
+        String columnName = this.table.getColumnName(column);
+        for (int rowIndex = 0; rowIndex < this.rows.size(); rowIndex++) {
+            if (rowIndex > 0) {
+                clipboardText.append(System.lineSeparator());
+            }
+
+            if (column == 0) {
+                clipboardText.append(rowIndex + 1);
+                continue;
+            }
+
+            Map<String, String> currentRow = TuplesExtractor.getRow_(this.rows.get(rowIndex), this.cell.getOperator(), true);
+            clipboardText.append(formatClipboardValue(currentRow.get(columnName)));
+        }
+
+        copyTextToClipboard(clipboardText.toString());
+    }
+
+    private void copyTextToClipboard(String text) {
+        StringSelection selection = new StringSelection(text);
         this.table.getToolkit().getSystemClipboard().setContents(selection, null);
     }
 
@@ -779,6 +899,13 @@ public class DataFrame extends JDialog implements ActionListener {    private fi
         public boolean isCellEditable(int row, int column) {
             return false;
         }
+    }
+
+    private enum TableSelectionType {
+        NONE,
+        CELL,
+        ROW,
+        COLUMN
     }
 
     private static class MovingSquareBar extends JPanel {


### PR DESCRIPTION
Melhora a interação do usuário com a tabela de resultados de uma query.

Agora o usuário pode selecionar e copiar o conteúdo da tabela de resultados de diferentes formas:
- Clicando ou arrastando, é possível selecionar uma célula, uma linha inteira, uma coluna, ou intervalos com múltiplas linhas e colunas;
- Ao clicar no cabeçalho de uma coluna, a coluna é selecionada e, ao copiar, são incluídos os valores dessa coluna em todas as tuplas já carregadas;
- É possível selecionar várias colunas pelo cabeçalho ao mesmo tempo;
- O novo botão "All" seleciona todas as colunas da tabela e, ao copiar, inclui todas as tuplas já carregadas;
- Ao alterar a largura de uma coluna, a nova largura é mantida ao navegar entre as páginas.